### PR TITLE
Set proper rev for processed deleted doc

### DIFF
--- a/src/couch_index_updater.erl
+++ b/src/couch_index_updater.erl
@@ -159,7 +159,9 @@ update(Idx, Mod, IdxState) ->
                 {false, <<"_design/", _/binary>>} ->
                     {nil, Seq};
                 _ when Deleted ->
-                    {#doc{id=DocId, deleted=true}, Seq};
+                    [RI|_] = DocInfo#doc_info.revs,
+                    {Pos, Rev} = RI#rev_info.rev,
+                    {#doc{id=DocId, revs={Pos, [Rev]}, deleted=true}, Seq};
                 _ ->
                     {ok, Doc} = couch_db:open_doc_int(Db, DocInfo, DocOpts),
                     {Doc, Seq}


### PR DESCRIPTION
View changes needs to return the "winning" rev to the client. With
default style, it does this by looking up the rev in the seq tree. Prior
to this commit, when a document was being deleted, the default rev (ie.
{0, []}) would be added to the seq tree. This commit fixes the problem
by manually setting the proper rev in the deleted #doc record before
it's processed.
