### PR TITLE
Allow get_index to receive DDoc as a doc record

### DIFF
--- a/src/couch_index_server.erl
+++ b/src/couch_index_server.erl
@@ -67,7 +67,10 @@ validate(DbName, DDoc) ->
 
 
 get_index(Module, #db{name = <<"shards/", _/binary>> = DbName}, DDoc) ->
-    get_index(Module, DbName, DDoc);
+    case is_record(DDoc, doc) of
+        true -> get_index(Module, DbName, DDoc, nil);
+        false -> get_index(Module, DbName, DDoc)
+    end;
 get_index(Module, <<"shards/", _/binary>> = DbName, DDoc) ->
     {Pid, Ref} = spawn_monitor(fun() ->
         exit(fabric:open_doc(mem3:dbname(DbName), DDoc, [ejson_body]))


### PR DESCRIPTION
The function `couch_mrview:compact/3` is passing to `get_index`
a prepared #doc record, when `get_index` is expecting DDoc
to be a ddoc's id. As a result view's compaction is crashing
after `fabric:open_doc` call.

This patch allows `get_index` to receive #doc record directly.

This closes COUCHDB-2729