### PR TITLE
Allow couch_index to open restricted design docs

### DIFF
--- a/src/couch_index.erl
+++ b/src/couch_index.erl
@@ -283,7 +283,7 @@ handle_cast(ddoc_updated, State) ->
     DbName = Mod:get(db_name, IdxState),
     DDocId = Mod:get(idx_name, IdxState),
     Shutdown = couch_util:with_db(DbName, fun(Db) ->
-        case couch_db:open_doc(Db, DDocId, [ejson_body]) of
+        case couch_db:open_doc(Db, DDocId, [ejson_body, ?ADMIN_CTX]) of
             {not_found, deleted} ->
                 true;
             {ok, DDoc} ->

--- a/src/couch_index_server.erl
+++ b/src/couch_index_server.erl
@@ -73,7 +73,7 @@ get_index(Module, #db{name = <<"shards/", _/binary>> = DbName}, DDoc) ->
     end;
 get_index(Module, <<"shards/", _/binary>> = DbName, DDoc) ->
     {Pid, Ref} = spawn_monitor(fun() ->
-        exit(fabric:open_doc(mem3:dbname(DbName), DDoc, [ejson_body]))
+        exit(fabric:open_doc(mem3:dbname(DbName), DDoc, [ejson_body, ?ADMIN_CTX]))
     end),
     receive {'DOWN', Ref, process, Pid, {ok, Doc}} ->
         get_index(Module, DbName, Doc, nil);
@@ -93,7 +93,7 @@ get_index(Module, DbName, DDoc, Fun) when is_binary(DbName) ->
         get_index(Module, Db, DDoc, Fun)
     end);
 get_index(Module, Db, DDoc, Fun) when is_binary(DDoc) ->
-    case couch_db:open_doc(Db, DDoc, [ejson_body]) of
+    case couch_db:open_doc(Db, DDoc, [ejson_body, ?ADMIN_CTX]) of
         {ok, Doc} -> get_index(Module, Db, Doc, Fun);
         Error -> Error
     end;


### PR DESCRIPTION
Design docs in the authentication DB cannot be opened without an
admin context so this commit teaches couch_index to always use
?ADMIN_CTX when opening documents.

COUCHDB-2738