### PR TITLE
Add travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+language: erlang
+
+otp_release:
+  - 18.1
+  - 18.0
+  - 17.5
+  - R16B03-1
+
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - libmozjs185-dev
+
+before_install:
+  - git clone --depth 1 https://github.com/apache/couchdb
+
+before_script:
+  - cd couchdb
+  - ./configure --disable-docs --disable-fauxton
+  - cp -r ../!(couchdb) ./src/couch_index
+  - make
+
+script:
+  - make eunit apps=couch_index skip_deps=couch_epi,couch_log
+
+cache: apt


### PR DESCRIPTION
This adds "standard" travis config to the project, so CI will stop failing when trying to run default ruby tests.

Since couch-index lacks tests, this is not a real check, but more of a placeholder. We can hold on adding this into repo until we build the proper eunits and instead turn on " Build only if .travis.yml is present" setting in travis for this repo. 