### PR TITLE
Use couch_server:delete_dir/2 on indexes reset

### DIFF
--- a/src/couch_index_server.erl
+++ b/src/couch_index_server.erl
@@ -229,7 +229,7 @@ reset_indexes(DbName, Root) ->
     end,
     lists:foreach(Fun, ets:lookup(?BY_DB, DbName)),
     Path = couch_index_util:index_dir("", DbName),
-    couch_file:nuke_dir(Root, Path).
+    couch_server:delete_dir(Root, Path).
 
 
 add_to_ets(DbName, Sig, DDocId, Pid) ->


### PR DESCRIPTION
This change allows couch_index to respect `rename_on_delete` option by using new couch_server's `delete_dir` function that renames ddoc directory instead of nuking it in this case. 

Companion PR for apache/couchdb-couch#141